### PR TITLE
fix packages search on Unix platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(pivy_cmake_setup NONE)
+project(pivy_cmake_setup)
 cmake_minimum_required(VERSION 3.5)
 
 


### PR DESCRIPTION
The CMakeLists.txt uses find_package() macro in CONFIG mode to detect coin and soqt packages information. These files on Unix platforms are normally searched in 

```
<prefix>/(lib/<arch>|lib*|share)/cmake/<name>*/ 
<prefix>/(lib/<arch>|lib*|share)/<name>*/ 
<prefix>/(lib/<arch>|lib*|share)/<name>*/(cmake|CMake)/
```

If the project type is NONE those paths are excluded from the search. Let's use the default project type which is C and CXX.