### PR TITLE
Fixed examples/examiner_embed4.py to be Qt5 compatible

### DIFF
--- a/examples/examiner_embed4.py
+++ b/examples/examiner_embed4.py
@@ -26,7 +26,10 @@ from random import random
 from pivy.coin import *
 from pivy.gui.soqt import *
 
-from PySide2.QtGui import *
+try:
+    from PySide2.QtWidgets import *
+except ImportError:
+    from PySide2.QtGui import *
 from PySide2.QtCore import *
 
 class EmbeddedWindow(QMainWindow):


### PR DESCRIPTION
These changes allow me to run this example on `Windows` with a [python-pivy](https://packages.msys2.org/base/mingw-w64-python-pivy) and [pisyde2-qt5](https://packages.msys2.org/base/mingw-w64-pyside2-qt5) packages.