### PR TITLE
Fix infinite recursion in SoBaseKit #85

### DIFF
--- a/Inventor/nodekits/SoBaseKit.i
+++ b/Inventor/nodekits/SoBaseKit.i
@@ -2,6 +2,8 @@
 %extend SoBaseKit {
 %pythoncode %{
     def __getattr__(self,name):
+       if name == 'this':
+          return SoNode.__getattr__(self,name)
        c = _coin.SoBaseKit_getNodekitCatalog(self)
        if c.getPartNumber(name) >= 0:
            part = self.getPart(name,1)


### PR DESCRIPTION
This PR detects when the `'this'` attribute is requested from `SoBaseKit` and returns the `SoNode` implementation.

Currently `SoBaseKit.__getattr__()` calls `SoBaseKit_getNodekitCatalog()` unconditionally, however `SoBaseKit_getNodekitCatalog` itself results in a request for the `'this'` attribute, leading to infinite recursion. At the moment this error is handled silently upstream, but can present an issue when using debuggers such as debugpy (#85). This fix handles the `'this'` attribute before this happens.