### PR TITLE
Tests no longer segfault on Python 3.10

### DIFF
--- a/.github/workflows/test-env-action.yml
+++ b/.github/workflows/test-env-action.yml
@@ -13,7 +13,7 @@ jobs:
       max-parallel: 9
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test-env-action.yml
+++ b/.github/workflows/test-env-action.yml
@@ -13,7 +13,7 @@ jobs:
       max-parallel: 9
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/interfaces/pivy_common_typemaps.i
+++ b/interfaces/pivy_common_typemaps.i
@@ -28,19 +28,12 @@ typedef int Py_ssize_t;
   #define IS_PY3K
 #endif
 
-/* a casting helper function */
-SWIGEXPORT PyObject *
-cast(PyObject * self, PyObject * args)
+PyObject *
+cast_internal(PyObject * self, PyObject * obj, const char * type_name, int type_len)
 {
   swig_type_info * swig_type = 0;
   void * cast_obj = 0;
-  char * type_name, * ptr_type;
-  int type_len;
-  PyObject * obj = 0;
-
-  if (!PyArg_ParseTuple(args, "Os#:cast", &obj, &type_name, &type_len)) {
-    SWIG_fail;
-  }
+  char * ptr_type;
 
   /*
    * add a pointer sign to the string coming from the interpreter
@@ -74,7 +67,24 @@ cast(PyObject * self, PyObject * args)
   if (SWIG_arg_fail(1)) { SWIG_fail; }
 
   return SWIG_NewPointerObj((void*)cast_obj, swig_type, 0);
-  fail:
+fail:
+  return NULL;
+}
+
+/* a casting helper function */
+SWIGEXPORT PyObject *
+cast(PyObject * self, PyObject * args)
+{
+  char * type_name;
+  int type_len;
+  PyObject * obj = 0;
+
+  if (!PyArg_ParseTuple(args, "Os#:cast", &obj, &type_name, &type_len)) {
+    SWIG_fail;
+  }
+
+  return cast_internal(self, obj, type_name, type_len);
+fail:
   return NULL;
 }
 
@@ -86,18 +96,15 @@ autocast_base(SoBase * base)
 
   /* autocast the result to the corresponding type */
   if (base && base->isOfType(SoFieldContainer::getClassTypeId())) {
-    PyObject * cast_args = NULL;
     PyObject * obj = NULL;
     SoType type = base->getTypeId();
 
     /* in case of a non built-in type get the closest built-in parent */
     while (!(type.isBad() || result)) {
       obj = SWIG_NewPointerObj((void*)base, SWIGTYPE_p_SoBase, 0);
-      cast_args = Py_BuildValue("(Os)", obj, type.getName().getString());
       
-      result = cast(NULL, cast_args);
+      result = cast_internal(NULL, obj, type.getName().getString(), type.getName().getLength());
 
-      Py_DECREF(cast_args);
       Py_DECREF(obj);
 
       if (!result) { type = type.getParent(); }
@@ -120,18 +127,15 @@ autocast_path(SoPath * path)
   
   /* autocast the result to the corresponding type */
   if (path) {
-    PyObject * cast_args = NULL;
     PyObject * obj = NULL;
     SoType type = path->getTypeId();
 
     /* in case of a non built-in type get the closest built-in parent */
     while (!(type.isBad() || result)) {
       obj = SWIG_NewPointerObj((void*)path, SWIGTYPE_p_SoPath, 0);
-      cast_args = Py_BuildValue("(Os)", obj, type.getName().getString());
       
-      result = cast(NULL, cast_args);
+      result = cast_internal(NULL, obj, type.getName().getString(), type.getName().getLength());
 
-      Py_DECREF(cast_args);
       Py_DECREF(obj);
 
       if (!result) { type = type.getParent(); }
@@ -154,18 +158,15 @@ autocast_field(SoField * field)
 
   /* autocast the result to the corresponding type */
   if (field) {
-    PyObject * cast_args = NULL;
     PyObject * obj = NULL;
     SoType type = field->getTypeId();
 
     /* in case of a non built-in type get the closest built-in parent */
     while (!(type.isBad() || result)) {
       obj = SWIG_NewPointerObj((void*)field, SWIGTYPE_p_SoField, 0);
-      cast_args = Py_BuildValue("(Os)", obj, type.getName().getString());
       
-      result = cast(NULL, cast_args);
+      result = cast_internal(NULL, obj, type.getName().getString(), type.getName().getLength());
 
-      Py_DECREF(cast_args);
       Py_DECREF(obj);
       
       if (!result) { type = type.getParent(); }
@@ -188,18 +189,15 @@ autocast_event(SoEvent * event)
   
   /* autocast the result to the corresponding type */
   if (event) {
-    PyObject * cast_args = NULL;
     PyObject * obj = NULL;
     SoType type = event->getTypeId();
 
     /* in case of a non built-in type get the closest built-in parent */
     while (!(type.isBad() || result)) {
       obj = SWIG_NewPointerObj((void*)event, SWIGTYPE_p_SoEvent, 0);
-      cast_args = Py_BuildValue("(Os)", obj, type.getName().getString());
       
-      result = cast(NULL, cast_args);
+      result = cast_internal(NULL, obj, type.getName().getString(), type.getName().getLength());
 
-      Py_DECREF(cast_args);
       Py_DECREF(obj);
 
       if (!result) { type = type.getParent(); }


### PR DESCRIPTION
Fixes https://github.com/coin3d/pivy/issues/88.

Had to do a ton of debugging and doc-hunting for this one.

According to the [`PyArg_ParseTuple()` docs](https://docs.python.org/3.10/extending/extending.html?highlight=pyarg_parsetuple#extracting-parameters-in-extension-functions):

> ```cpp
> int PyArg_ParseTuple(PyObject *arg, const char *format, ...);
> ```
> The _arg_ argument must be a tuple object containing an argument list passed from Python to a C function.

`autocast_base`, `autocast_path`, `autocast_field`, `autocast_event` were all _building a new tuple_ to take advantage of code reuse with the `cast` function, which would then re-parse the tuple using `PyArg_ParseTuple`. As per the docs, `PyArg_ParseTuple` should only ever be passed an object directly from Python. Receiving the newly built tuple was causing segfaults.

I've solved this by creating a new unexported `cast_internal` function that gets called by all 5 of the above functions, directly taking the objects from inside an already-parsed tuple. `PyArg_ParseTuple` is now only called by the SWIG-exported functions.

In addition to running the tests successfully, I've confirmed that this fixes the issues with the FreeCAD Path, Draft, and Architecture workbenches on Arch Linux.