### PR TITLE
Correct Python install directory to be arch specific

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,13 +14,12 @@ if (SoQt_FOUND)
     find_package(Qt5 COMPONENTS Core Widgets Gui REQUIRED)
 endif()
 
-find_package(PythonInterp REQUIRED)
-find_package(PythonLibs REQUIRED)
+find_package(Python REQUIRED COMPONENTS Interpreter Development)
 
 # SWIGIFY HEADERS
 # doing this with the origin python functions
 
-execute_process(COMMAND ${PYTHON_EXECUTABLE} -c
+execute_process(COMMAND ${Python_EXECUTABLE} -c
 "import sys; sys.path.append('${CMAKE_SOURCE_DIR}'); \
 import install_helpers; install_helpers.swigify('${CMAKE_SOURCE_DIR}', '${Coin_INCLUDE_DIR}');")
 
@@ -34,18 +33,11 @@ add_copy_directory(pivy ${CMAKE_SOURCE_DIR}/pivy
     PATTERN *.py
 )
 
-
-# find python install destination
-
-execute_process(COMMAND ${PYTHON_EXECUTABLE} -c
-  "from distutils.sysconfig import get_python_lib; print(get_python_lib())"
-  OUTPUT_VARIABLE python_libs OUTPUT_STRIP_TRAILING_WHITESPACE )
-
 add_subdirectory(interfaces)
 
 install(DIRECTORY
     ${CMAKE_BINARY_DIR}/pivy
-    DESTINATION ${python_libs}
+    DESTINATION ${Python_SITEARCH}
     FILES_MATCHING
     PATTERN "*.py"
     PATTERN "*.so"

--- a/interfaces/CMakeLists.txt
+++ b/interfaces/CMakeLists.txt
@@ -28,19 +28,19 @@ if (APPLE)
     set_target_properties(coin PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
 elseif (WIN32)
     set_target_properties(coin PROPERTIES COMPILE_FLAGS "/bigobj")
-    target_link_libraries(coin PUBLIC ${PYTHON_LIBRARIES})
+    target_link_libraries(coin PUBLIC ${Python_LIBRARIES})
 endif ()
 
 target_include_directories(coin
     PUBLIC
     ${Coin_INCLUDE_DIR}
-    ${PYTHON_INCLUDE_DIRS}
+    ${Python_INCLUDE_DIRS}
     PRIVATE
     ${CMAKE_SOURCE_DIR}/interfaces
     )
 
 target_link_libraries(coin PUBLIC Coin::Coin)
-install(TARGETS coin DESTINATION ${python_libs}/pivy)
+install(TARGETS coin DESTINATION ${Python_SITEARCH}/pivy)
 
 
 if (SoQt_FOUND)
@@ -63,7 +63,7 @@ if (SoQt_FOUND)
         set_target_properties(soqt PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
     elseif (WIN32)
         set_target_properties(coin PROPERTIES COMPILE_FLAGS "/bigobj")
-        target_link_libraries(soqt PUBLIC ${PYTHON_LIBRARIES})
+        target_link_libraries(soqt PUBLIC ${Python_LIBRARIES})
     endif ()
 
     target_include_directories(soqt
@@ -71,11 +71,11 @@ if (SoQt_FOUND)
         ${SoQt_INCLUDE_DIRS}
         ${Qt5Gui_INCLUDE_DIRS}
         ${Qt5Widgets_INCLUDE_DIRS}
-        ${PYTHON_INCLUDE_DIRS}
+        ${Python_INCLUDE_DIRS}
         PRIVATE
         ${CMAKE_SOURCE_DIR}/interfaces
         )
 
     target_link_libraries(soqt PUBLIC SoQt::SoQt)
-    install(TARGETS soqt DESTINATION ${python_libs}/pivy/gui)
+    install(TARGETS soqt DESTINATION ${Python_SITEARCH}/pivy/gui)
 endif()


### PR DESCRIPTION
Binary (i.e. non-pure) python modules should be installed to an
arch specific directory.
Instead of doing this manually, use the Python_SITEARCH variable
provided by the new FindPython module, available since CMake 3.12.