### PR TITLE
Fix undefined behavior in coin.cast and soqt.cast functions

### DIFF
--- a/interfaces/pivy_common_typemaps.i
+++ b/interfaces/pivy_common_typemaps.i
@@ -29,7 +29,7 @@ typedef int Py_ssize_t;
 #endif
 
 PyObject *
-cast_internal(PyObject * self, PyObject * obj, const char * type_name, int type_len)
+cast_internal(PyObject * self, PyObject * obj, const char * type_name, Py_ssize_t type_len)
 {
   swig_type_info * swig_type = 0;
   void * cast_obj = 0;
@@ -76,7 +76,7 @@ SWIGEXPORT PyObject *
 cast(PyObject * self, PyObject * args)
 {
   char * type_name;
-  int type_len;
+  Py_ssize_t type_len;
   PyObject * obj = 0;
 
   if (!PyArg_ParseTuple(args, "Os#:cast", &obj, &type_name, &type_len)) {

--- a/interfaces/soqt.i
+++ b/interfaces/soqt.i
@@ -23,6 +23,9 @@ otherwise it will fall back to regular SWIG structures."
 
 %module(package="pivy.gui", docstring=SOQT_MODULE_DOCSTRING) soqt
 
+%begin %{
+#define PY_SSIZE_T_CLEAN
+%}
 
 %{
 /*


### PR DESCRIPTION
If the  macro `PY_SSIZE_T_CLEAN` is defined (mandatory in Python 3.10), when parsing arguments with `#` variants of formats (`s#`, `y#,` etc.) the type of the length argument must be `Py_ssize_t`.
This is related to https://github.com/coin3d/pivy/pull/91.
The problem is not due to what is described in #91, but to the type of the argument.
The implementation proposed in #91 for the functions `cast` and  `cast_internal` only fix the crash in those cases when only `cast_internal` is used, but `cast` still crash, for example. when creating the quarter widget.

To reproduce the crash:
```
from pivy import coin
from pivy.gui import soqt
s=coin.SoTransform()
coin.cast(s, "SoNode") --> crash
soqt.cast(s, "SoNode") --> SystemError in Python >= 3.10
```
But most important:
```
from PySide2.QtWidgets import QApplication
from pivy import quarter
app = QApplication()
q = quarter.QuarterWidget() --> crash
```