### PR TITLE
Use PySide6 instead of PySide2 to get QtDesigner

### DIFF
--- a/pivy/quarter/plugins/designer/python/PyQuarterWidgetPlugin.py
+++ b/pivy/quarter/plugins/designer/python/PyQuarterWidgetPlugin.py
@@ -22,7 +22,7 @@ $install_prefix/site-packages/pivy/quarter/plugins to the
 QT_PLUGIN_PATH environment variable.
 """
 
-from PySide2 import QtGui, QtCore, QtDesigner
+from PySide6 import QtGui, QtCore, QtDesigner
 from pivy import coin, quarter
 
 class PyQuarterWidgetPlugin(QtDesigner.QPyDesignerCustomWidgetPlugin):


### PR DESCRIPTION
There is no QtDesigner in PySide2

```
>>> PySide2.__version__
'5.13.2'
>>> from PySide2 import QtDesigner
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: cannot import name 'QtDesigner' from 'PySide2' (/tmp/.private/kotopesutility/VENV/lib64/python3/site-packages/PySide2/__init__.py)
```