### PR TITLE
Update sogui.py to prevent QApplication singleton destruction issue

### DIFF
--- a/pivy/sogui.py
+++ b/pivy/sogui.py
@@ -119,7 +119,9 @@ if not gui:
         class SoGui(object):
             @staticmethod
             def init(*args):
-                SoGui_Quarter_Wrapper.qApp = QtWidgets.QApplication(sys.argv)
+                SoGui_Quarter_Wrapper.qApp = QtWidgets.QApplication.instance()
+                if SoGui_Quarter_Wrapper.qApp is None: 
+                    SoGui_Quarter_Wrapper.qApp = QtWidgets.QApplication(sys.argv)
                 return pivy.quarter.QuarterWidget()
 
             @staticmethod


### PR DESCRIPTION
Solves the following error: 
" File "/usr/lib/python3/dist-packages/pivy/sogui.py", line 122, in init
    SoGui_Quarter_Wrapper.qApp = QtWidgets.QApplication(sys.argv)
RuntimeError: Please destroy the QApplication singleton before creating a new QApplication instance."

Without this change, the existing singleton of QApplication prevents a new window to open after a previous one has been closed. This solution works and has been suggested online for PySide2 several times.