### PR TITLE
Fix issues with PySide6

### DIFF
--- a/interfaces/CMakeLists.txt
+++ b/interfaces/CMakeLists.txt
@@ -66,11 +66,16 @@ if (SoQt_FOUND)
         target_link_libraries(soqt PUBLIC ${Python_LIBRARIES})
     endif ()
 
+    if (PIVY_USE_QT6)
+        set(QT_INC_DIRS ${Qt6Gui_INCLUDE_DIRS} ${Qt6Widgets_INCLUDE_DIRS})
+    else ()
+        set(QT_INC_DIRS ${Qt5Gui_INCLUDE_DIRS} ${Qt5Widgets_INCLUDE_DIRS})
+    endif ()
+
     target_include_directories(soqt
         PUBLIC
         ${SoQt_INCLUDE_DIRS}
-        ${Qt5Gui_INCLUDE_DIRS}
-        ${Qt5Widgets_INCLUDE_DIRS}
+        ${QT_INC_DIRS}
         ${Python_INCLUDE_DIRS}
         PRIVATE
         ${CMAKE_SOURCE_DIR}/interfaces

--- a/interfaces/soqt.i
+++ b/interfaces/soqt.i
@@ -119,6 +119,12 @@ template <typename T> const char* get_typename(T& object)
 #endif
 /////////////////////////////////////////////////////
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#define SHIBOKEN "shiboken6"
+#else
+#define SHIBOKEN "shiboken2"
+#endif
+
 static const char * PYSIDE_QT = "pivy.gui.qt";
 
 static PyObject* getShiboken()
@@ -128,9 +134,9 @@ static PyObject* getShiboken()
   // pip installs it in a wrong place
   // if you have installed shiboken with pip please symlink to correct directory
   PyObject * shiboken = NULL;
-  if (!(shiboken = PyDict_GetItemString(PyModule_GetDict(PyImport_AddModule("__main__")), "shiboken2"))) {
+  if (!(shiboken = PyDict_GetItemString(PyModule_GetDict(PyImport_AddModule("__main__")), SHIBOKEN))) {
     // simple import shiboken from python.
-   shiboken = PyImport_ImportModule("shiboken2");
+   shiboken = PyImport_ImportModule(SHIBOKEN);
   }
   return shiboken;
 }

--- a/pivy/qt/QtWidgets/__init__.py
+++ b/pivy/qt/QtWidgets/__init__.py
@@ -1,5 +1,4 @@
 try:
     from PySide6.QtWidgets import *
-    from PySide6.QtGui import QActionGroup
 except ImportError:
     from PySide2.QtWidgets import *

--- a/pivy/quarter/ContextMenu.py
+++ b/pivy/quarter/ContextMenu.py
@@ -17,7 +17,12 @@
 from pivy.qt import QtCore
 from pivy.qt.QtCore import QObject
 from pivy.qt.QtGui import QMouseEvent
-from pivy.qt.QtWidgets import QMenu, QActionGroup, QAction
+from pivy.qt.QtWidgets import QMenu
+
+try:
+    from pivy.qt.QtGui import QActionGroup, QAction
+except ImportError:
+    from pivy.qt.QtWidgets import QActionGroup, QAction
 
 from pivy import coin
 from pivy.coin import SoEventManager, SoScXMLStateMachine, SoRenderManager, SoGLRenderAction

--- a/pivy/quarter/devices/DeviceHandler.py
+++ b/pivy/quarter/devices/DeviceHandler.py
@@ -35,6 +35,6 @@ class DeviceHandler:
         # Note: On Mac OS X, the ControlModifier value corresponds to the
         # Command keys on the Macintosh keyboard, and the MetaModifier
         # value corresponds to the Control keys.
-        soevent.setShiftDown(int(qevent.modifiers() & QtCore.Qt.ShiftModifier) == QtCore.Qt.ShiftModifier)    
-        soevent.setAltDown(int(qevent.modifiers() & QtCore.Qt.AltModifier) == QtCore.Qt.AltModifier)
-        soevent.setCtrlDown(int(qevent.modifiers() & QtCore.Qt.ControlModifier) == QtCore.Qt.ControlModifier)
+        soevent.setShiftDown(qevent.modifiers() & QtCore.Qt.ShiftModifier == QtCore.Qt.ShiftModifier)
+        soevent.setAltDown(qevent.modifiers() & QtCore.Qt.AltModifier == QtCore.Qt.AltModifier)
+        soevent.setCtrlDown(qevent.modifiers() & QtCore.Qt.ControlModifier == QtCore.Qt.ControlModifier)

--- a/pivy/quarter/devices/MouseHandler.py
+++ b/pivy/quarter/devices/MouseHandler.py
@@ -74,7 +74,7 @@ class MouseHandler(DeviceHandler):
         # value indicates that the wheel was rotated backwards toward the
         # user.
 
-        if qevent.delta() > 0:
+        if qevent.angleDelta().y() > 0:
             self.mousebutton.setButton(coin.SoMouseButtonEvent.BUTTON4)
         else:
             self.mousebutton.setButton(coin.SoMouseButtonEvent.BUTTON5)
@@ -97,7 +97,7 @@ class MouseHandler(DeviceHandler):
             self.mousebutton.setButton(coin.SoMouseButtonEvent.BUTTON1)
         elif qevent.button() == QtCore.Qt.RightButton:
             self.mousebutton.setButton(coin.SoMouseButtonEvent.BUTTON2)
-        elif qevent.button() == QtCore.Qt.MidButton:
+        elif qevent.button() == QtCore.Qt.MiddleButton:
             self.mousebutton.setButton(coin.SoMouseButtonEvent.BUTTON3)
         else:
             self.mousebutton.setButton(coin.SoMouseButtonEvent.ANY)


### PR DESCRIPTION
When using pivy, either SoQt or Quarter, with PySide6 many errors occur like an attribute not being part of a Qt module or invalid type conversions show up in console. This PR addresses issues that might not have been caught earlier since the last prerelease. I've checked out with the Qt documentation so that this remains compatible with PySide2 but please mention any issue that might show up. Also this reverts #117 because it was a solution only specific to one part of the code.
