### PR TITLE
support building with vcpkg

### DIFF
--- a/.github/workflows/build-with-vcpkg.yml
+++ b/.github/workflows/build-with-vcpkg.yml
@@ -22,6 +22,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Install SWIG (macOS only)
+        if: matrix.config.os == 'macos-latest'
+        run: |
+          brew install swig@4
+          brew link --overwrite swig@4
+
       - name: vcpkg build
         uses: johnwason/vcpkg-action@v6
         id: vcpkg

--- a/.github/workflows/build-with-vcpkg.yml
+++ b/.github/workflows/build-with-vcpkg.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       matrix:
         config:
-          - os: ubuntu-latest
-            vcpkg_triplet: x64-linux-release
+          # - os: ubuntu-latest
+          #   vcpkg_triplet: x64-linux-release
           - os: macos-latest
             vcpkg_triplet: x64-osx-release
           - os: windows-latest
@@ -21,12 +21,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-
-      - name: Install dependencies (Ubuntu only)
-        if: matrix.config.os == 'ubuntu-latest'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y autoconf automake libtool pkg-config
 
       - name: vcpkg build
         uses: johnwason/vcpkg-action@v6

--- a/.github/workflows/build-with-vcpkg.yml
+++ b/.github/workflows/build-with-vcpkg.yml
@@ -19,7 +19,7 @@ jobs:
 
             - name: Configure CMake
               run: |
-                    cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake
+                    cmake -S . -B build --toolchain $env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake
 
             - name: Build project
               run: |

--- a/.github/workflows/build-with-vcpkg.yml
+++ b/.github/workflows/build-with-vcpkg.yml
@@ -1,26 +1,42 @@
 name: Build with vcpkg
 
 on:
-    push:
-        # branches:
-        #     - main
-    pull_request:
+  push:
+    # branches:
+    #   - main
+  pull_request:
 
 jobs:
-    build:
-        runs-on: windows-latest
-        permissions: 
-            actions: read
-            contents: read
+  buildme:
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      matrix:
+        config:
+          - os: ubuntu-latest
+            vcpkg_triplet: x64-linux-release
+          - os: macos-latest
+            vcpkg_triplet: x64-osx-release
+          - os: windows-latest
+            vcpkg_triplet: x64-windows-release
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
 
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v3
+      - name: vcpkg build
+        uses: johnwason/vcpkg-action@v6
+        id: vcpkg
+        with:
+          manifest-dir: ${{ github.workspace }}
+          triplet: ${{ matrix.config.vcpkg_triplet }}
+          cache-key: ${{ matrix.config.os }}
+          revision: master
+          token: ${{ github.token }}
+          github-binarycache: true
 
-            - name: Configure CMake
-              run: |
-                    cmake -S . -B build --toolchain $env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake
+      - name: Configure CMake
+        run: |
+          cmake -S . -B build ${{ steps.vcpkg.outputs.vcpkg-cmake-config }}
 
-            - name: Build project
-              run: |
-                    cmake --build build --config Release
+      - name: Build project
+        run: |
+          cmake --build build --config Release

--- a/.github/workflows/build-with-vcpkg.yml
+++ b/.github/workflows/build-with-vcpkg.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - build_with_vcpkg
   pull_request:
     branches:
       - master
@@ -24,6 +25,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
       - name: Install SWIG (macOS only)
         if: matrix.config.os == 'macos-latest'
         run: |
@@ -43,8 +49,12 @@ jobs:
 
       - name: Configure CMake
         run: |
-          cmake -S . -B build ${{ steps.vcpkg.outputs.vcpkg-cmake-config }}
+          cmake -S . -B build -G Ninja -DCMAKE_INSTALL_PREFIX:PATH=${{ github.workspace }}/out -DCMAKE_BUILD_TYPE:STRING=Release -DX_VCPKG_APPLOCAL_DEPS_INSTALL:BOOLEAN=ON ${{ steps.vcpkg.outputs.vcpkg-cmake-config }}
 
       - name: Build project
         run: |
           cmake --build build --config Release
+      
+      - name: Install project
+        run: |
+          cmake --install build --config Release

--- a/.github/workflows/build-with-vcpkg.yml
+++ b/.github/workflows/build-with-vcpkg.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Configure CMake
         run: |
-          cmake -S . -B build -G Ninja -DCMAKE_INSTALL_PREFIX:PATH=${{ github.workspace }}/out -DCMAKE_BUILD_TYPE:STRING=Release -DX_VCPKG_APPLOCAL_DEPS_INSTALL:BOOLEAN=ON ${{ steps.vcpkg.outputs.vcpkg-cmake-config }}
+          cmake -S . -B build -DCMAKE_INSTALL_PREFIX:PATH=${{ github.workspace }}/out -DCMAKE_BUILD_TYPE:STRING=Release -DX_VCPKG_APPLOCAL_DEPS_INSTALL:BOOLEAN=ON ${{ steps.vcpkg.outputs.vcpkg-cmake-config }}
 
       - name: Build project
         run: |

--- a/.github/workflows/build-with-vcpkg.yml
+++ b/.github/workflows/build-with-vcpkg.yml
@@ -22,6 +22,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Install dependencies (Ubuntu only)
+        if: matrix.config.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y autoconf automake libtool pkg-config
+
       - name: vcpkg build
         uses: johnwason/vcpkg-action@v6
         id: vcpkg

--- a/.github/workflows/build-with-vcpkg.yml
+++ b/.github/workflows/build-with-vcpkg.yml
@@ -1,0 +1,26 @@
+name: Build with vcpkg
+
+on:
+    push:
+        # branches:
+        #     - main
+    pull_request:
+
+jobs:
+    build:
+        runs-on: windows-latest
+        permissions: 
+            actions: read
+            contents: read
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
+
+            - name: Configure CMake
+              run: |
+                    cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake
+
+            - name: Build project
+              run: |
+                    cmake --build build --config Release

--- a/.github/workflows/build-with-vcpkg.yml
+++ b/.github/workflows/build-with-vcpkg.yml
@@ -2,9 +2,11 @@ name: Build with vcpkg
 
 on:
   push:
-    # branches:
-    #   - main
+    branches:
+      - master
   pull_request:
+    branches:
+      - master
 
 jobs:
   buildme:

--- a/.github/workflows/build-with-vcpkg.yml
+++ b/.github/workflows/build-with-vcpkg.yml
@@ -25,8 +25,8 @@ jobs:
       - name: Install SWIG (macOS only)
         if: matrix.config.os == 'macos-latest'
         run: |
-          brew install swig@4
-          brew link --overwrite swig@4
+          brew install swig
+          brew link --overwrite swig
 
       - name: vcpkg build
         uses: johnwason/vcpkg-action@v6

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,8 @@ build/
 **.so
 **.o
 **.sconsign*
-Inventor/**.h
+Inventor/*.h
+Inventor/**/**.h
 VolumeViz/**.h
 SoPyScript/swigpyrun.h
 examples/SoPyScript/examin

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ Starting with version 0.6.6 pivy it's possible to build pivy with cmake:
   $ cd pivy
   $ mkdir build
   $ cd build
-  $ cmake ..
-  $ make
+  $ cmake .. --toolchain $VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake -DCMAKE_BUILD_TYPE:STRING=Release -DPython_ROOT_DIR:PATH="path/to/python/root/dir" -DX_VCPKG_APPLOCAL_DEPS_INSTALL:BOOLEAN=ON
+  $ cmake --build .
+  $ cmake --install .
 ```
 
 Alternative it's still possible to use [distutils][0]:

--- a/interfaces/CMakeLists.txt
+++ b/interfaces/CMakeLists.txt
@@ -26,10 +26,10 @@ swig_add_library(coin
 
 if (APPLE)
     set_target_properties(coin PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
-elseif (MSVC)
+endif()
+
+if (MSVC)
     set_target_properties(coin PROPERTIES COMPILE_FLAGS "/bigobj")
-elseif(WIN32)
-    target_link_libraries(coin PUBLIC ${Python_LIBRARIES})
 endif ()
 
 target_include_directories(coin
@@ -40,7 +40,7 @@ target_include_directories(coin
     ${CMAKE_SOURCE_DIR}/interfaces
     )
 
-target_link_libraries(coin PUBLIC Coin::Coin)
+target_link_libraries(coin PUBLIC Coin::Coin Python::Module)
 install(TARGETS coin DESTINATION ${PIVY_Python_SITEARCH}/pivy)
 
 
@@ -63,10 +63,10 @@ if (SoQt_FOUND)
 
     if (APPLE)
         set_target_properties(soqt PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
-    elseif (MSVC)
+    endif()
+
+    if (MSVC)
         set_target_properties(coin PROPERTIES COMPILE_FLAGS "/bigobj")
-    elseif (WIN32)
-        target_link_libraries(soqt PUBLIC ${Python_LIBRARIES})
     endif ()
 
     if (PIVY_USE_QT6)
@@ -85,6 +85,6 @@ if (SoQt_FOUND)
         ${CMAKE_SOURCE_DIR}/interfaces
         )
 
-    target_link_libraries(soqt PUBLIC SoQt::SoQt)
+    target_link_libraries(soqt PUBLIC SoQt::SoQt Python::Module)
     install(TARGETS soqt DESTINATION ${PIVY_Python_SITEARCH}/pivy/gui)
 endif()

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,0 +1,14 @@
+{
+  "default-registry": {
+    "kind": "git",
+    "baseline": "5e5d0e1cd7785623065e77eff011afdeec1a3574",
+    "repository": "https://github.com/microsoft/vcpkg"
+  },
+  "registries": [
+    {
+      "kind": "artifact",
+      "location": "https://github.com/microsoft/vcpkg-ce-catalog/archive/refs/heads/main.zip",
+      "name": "microsoft"
+    }
+  ]
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": [
+    "soqt"
+  ]
+}


### PR DESCRIPTION
add instructions to build the library while using `vcpkg` to get the soqt/coin dependencies and install them along side the built *.pyd.

I only tested it on windows 11, but it should works on other platforms too.