### PR TITLE
Avoid DeprecationWarning: invalid escape sequence

### DIFF
--- a/pivy/quarter/QuarterWidget.py
+++ b/pivy/quarter/QuarterWidget.py
@@ -14,7 +14,7 @@
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
 
-"""
+r"""
   Quarter is a light-weight glue library that provides seamless
   integration between Systems in Motions's \COIN high-level 3D
   visualization library and Trolltech's \QT 2D user interface


### PR DESCRIPTION
This is a very small fix to avoid the deprecation warning I see in my test suite see: https://github.com/Fusion-Power-Plant-Framework/bluemira/pull/3884#issuecomment-2809905173