### PR TITLE
fix distutils_cmake project property

### DIFF
--- a/distutils_cmake/CMakeLists.txt
+++ b/distutils_cmake/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
-project(pivy_cmake_setup NONE)
+project(pivy_cmake_setup CXX)
 
 
 find_package(Coin CONFIG REQUIRED)


### PR DESCRIPTION
When building with Qt6, FindThreads only works if
either C or CXX language is enabled.