### PR TITLE
Adjust Python bindings for SWIG >= 4.4.

### DIFF
--- a/interfaces/coin.i
+++ b/interfaces/coin.i
@@ -80,7 +80,11 @@ static int init_file_emulator(void)
 %init %{
 #if PY_MAJOR_VERSION >= 3
 if (init_file_emulator() < 0) {
+  #if (SWIG_VERSION < 0x040400)
     return NULL;
+  #else
+    return 0;
+  #endif
 }
 #endif
 %}


### PR DESCRIPTION
Function signature changed in SWIG 4.4. Details:
https://github.com/numpy/numpy/commit/1e424dae42a2d560520b6e053e8e60ac4205bfc7