### PR TITLE
Fix fd.close() call in install_helpers.py

### DIFF
--- a/install_helpers.py
+++ b/install_helpers.py
@@ -30,7 +30,7 @@ def swigify_header(header_file, include_file):
     else:
         print("[failed]")
         sys.exit(1)
-    fd.close
+    fd.close()
 
 
 def copy_and_swigify_header(interface_dir, include_dir, fname):


### PR DESCRIPTION
This file was actually being left open: without the parens, it's just an assertion that the `close` method exists.