### PR TITLE
Add conditional check for Coin::Coin alias creation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,9 @@ else()
     set(Coin_INCLUDE_DIR ${Coin_SOURCE_DIR}/include)
     set(Coin_GENERATED_INCLUDE_DIR ${Coin_BINARY_DIR}/include)
 
-    add_library(Coin::Coin ALIAS Coin)
+    if (NOT TARGET Coin::Coin)
+        add_library(Coin::Coin ALIAS Coin)
+    endif()
 endif()
 find_package(SoQt CONFIG)
 


### PR DESCRIPTION
Make sure to only try to create the `Coin::Coin` alias if it doesn't already exist.